### PR TITLE
revert: 5 minute offset to some event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyhelper-utils",
-  "version": "1.2.19",
+  "version": "1.2.20",
   "description": "Utilities for SkyHelper bot",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/constants/eventDatas.ts
+++ b/src/constants/eventDatas.ts
@@ -46,7 +46,7 @@ export const eventData: EventData = {
     name: "Geyser",
     index: 0,
     duration: 10,
-    offset: 5,
+    offset: 0,
     infographic: {
       by: "Clement",
       image:
@@ -59,7 +59,7 @@ export const eventData: EventData = {
     name: "Grandma",
     index: 1,
     duration: 10,
-    offset: 35,
+    offset: 30,
     infographic: {
       by: "Clement",
       image:


### PR DESCRIPTION
Previously, Grandma and Geyser had an extra 5-minute offset. While this accurately reflected their actual occurrence time, using the official time is relatively better in that it allows users some time to prepare for them.